### PR TITLE
opentelemetry-instrumentation-threading 0.59b0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-threading" %}
-{% set version = "0.58b0" %}
+{% set version = "0.59b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: f68c61f77841f9ff6270176f4d496c10addbceacd782af434d705f83e4504862
+  sha256: ce5658730b697dcbc0e0d6d13643a69fd8aeb1b32fa8db3bade8ce114c7975f3
 
 build:
   number: 0


### PR DESCRIPTION
opentelemetry-instrumentation-threading 0.59b0 

**Destination channel:** Defaults

### Links

- [PKG-11135]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.59b0
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-threading-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-threading/0.59b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-threading/0.59b0

### Explanation of changes:

- new version number


[PKG-11135]: https://anaconda.atlassian.net/browse/PKG-11135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ