### PR TITLE
opentelemetry-instrumentation-threading 0.64b0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "opentelemetry-instrumentation-threading" %}
-{% set version = "0.59b0" %}
+{% set version = "0.64b0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: ce5658730b697dcbc0e0d6d13643a69fd8aeb1b32fa8db3bade8ce114c7975f3
+  sha256: 0a07d7329f69dfae5036a7cb184f502c8b91cb0538012f5304bd32ffe9ade451
 
 build:
   number: 0
@@ -23,7 +23,7 @@ requirements:
     - python
     - opentelemetry-api >=1.12,<2
     - opentelemetry-instrumentation =={{ version }}
-    - wrapt >=1.0.0,<2.0.0
+    - wrapt >=1.0.0,<3.0.0
 
 # Tests disabled:
 # E   ModuleNotFoundError: No module named 'opentelemetry.test'


### PR DESCRIPTION
opentelemetry-instrumentation-threading 0.64b0 

**Destination channel:** Defaults

### Links

- [PKG-16303]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.64b0
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-threading-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-threading/0.64b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-threading/0.64b0

### Explanation of changes:

- new version number


[PKG-16303]: https://anaconda.atlassian.net/browse/PKG-16303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ